### PR TITLE
Add #torrent-set-location support

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,13 @@ Or install it yourself as:
         :url      => "http://127.0.0.1:9091/transmission/rpc"
       )
 
+
     torrents = transmission_api_client.all
     torrent = transmission_api_client.find(id)
-    torrent = transmission_api_client.create("http://torrent.com/nice_pic.torrent")
+    torrents = transmission_api_client.find_all([id1, id2, id3])
+    torrent = transmission_api_client.create("http://torrent.com/nice_pic.torrent") # or magnet URL
+    result = transmission_api_client.move(id, "/new/container/for/torrent/")
+    result = transmission_api_client.move([id, id2, id3], "/new/container/for/torrent/")
     transmission_api_client.destroy(id)
 
 ## State

--- a/lib/transmission_api/client.rb
+++ b/lib/transmission_api/client.rb
@@ -116,6 +116,21 @@ class TransmissionApi::Client
     response
   end
 
+  def remove(id)
+    log "remove_torrent_nondestructive: #{id}"
+
+    response =
+      post(
+        :method => "torrent-remove",
+        :arguments => {
+          :ids => [id],
+          :"delete-local-data" => false
+        }
+      )
+
+    response
+  end
+
   def post(opts)
     response_parsed = JSON::parse( http_post(opts).body )
 

--- a/lib/transmission_api/client.rb
+++ b/lib/transmission_api/client.rb
@@ -54,6 +54,39 @@ class TransmissionApi::Client
     response["arguments"]["torrents"].first
   end
 
+  def find_all(ids)
+    log "get_torrents: #{ids}"
+
+    response =
+      post(
+        :method => "torrent-get",
+        :arguments => {
+          :fields => fields,
+          :ids => ids
+        }
+      )
+
+    response["arguments"]["torrents"]
+  end
+
+  def move(ids, new_location)
+    log "move_torrents: #{ids}"
+
+    ids = [ids] if !ids.is_a? Array
+
+    response =
+      post(
+        :method => "torrent-set-location",
+        :arguments => {
+          :ids => ids,
+          :location => new_location,
+          :move => true
+        }
+      )
+
+    response["arguments"] # seems empty if all is successful
+  end
+
   def create(filename)
     log "add_torrent: #{filename}"
 

--- a/lib/transmission_api/version.rb
+++ b/lib/transmission_api/version.rb
@@ -1,3 +1,3 @@
 module TransmissionApi
-  VERSION = "0.0.7"
+  VERSION = "0.0.8"
 end


### PR DESCRIPTION
- adds ability to set the location of the torrent
- adds ability to `find([id1, id2])` with multiple IDs
