### PR TITLE
Ability to override fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ Or install it yourself as:
       )
 
     torrents = transmission_api_client.all
+    # same as .all without arguments, but fetches only specified fields
+    torrents = transmission_api_client.all(fields: ['id', 'name', 'addedDate'])
+
     torrent = transmission_api_client.find(id)
     torrent = transmission_api_client.create("http://torrent.com/nice_pic.torrent")
     transmission_api_client.destroy(id)

--- a/README.md
+++ b/README.md
@@ -34,8 +34,10 @@ Or install it yourself as:
     torrents = transmission_api_client.all
     # same as .all without arguments, but fetches only specified fields
     torrents = transmission_api_client.all(fields: ['id', 'name', 'addedDate'])
-
+    # find with default fields
     torrent = transmission_api_client.find(id)
+    # find with custom fields
+    torrent = transmission_api_client.find(id, fields: ['id', 'name'])
     torrent = transmission_api_client.create("http://torrent.com/nice_pic.torrent")
     transmission_api_client.destroy(id)
 

--- a/lib/transmission_api/client.rb
+++ b/lib/transmission_api/client.rb
@@ -30,30 +30,27 @@ class TransmissionApi::Client
 
     fields = opts.fetch(:fields) { self.fields }
 
-    response =
-      post(
-        :method => "torrent-get",
-        :arguments => {
-          :fields => fields
-        }
-      )
-
-    response["arguments"]["torrents"]
+    get_torrents(fields: fields)
   end
 
-  def find(id)
+  def find(id, opts = {})
     log "get_torrent: #{id}"
 
-    response =
-      post(
-        :method => "torrent-get",
-        :arguments => {
-          :fields => fields,
-          :ids => [id]
-        }
-      )
+    fields = opts.fetch(:fields) { self.fields }
 
-    response["arguments"]["torrents"].first
+    get_torrents(:fields => fields,
+                 :ids => [id]).first
+  end
+
+
+  def get_torrents(arguments)
+    log "get_torrents"
+
+    post_params = { :method => "torrent-get", arguments: arguments }
+
+    response = post(post_params)
+
+    response["arguments"]["torrents"]
   end
 
   def create(filename)
@@ -78,7 +75,7 @@ class TransmissionApi::Client
         :method => "torrent-remove",
         :arguments => {
           :ids => [id],
-          :"delete-local-data" => true
+                       :"delete-local-data" => true
         }
       )
 

--- a/lib/transmission_api/client.rb
+++ b/lib/transmission_api/client.rb
@@ -25,8 +25,10 @@ class TransmissionApi::Client
     @debug_mode = opts[:debug_mode] || false
   end
 
-  def all
+  def all(opts = {})
     log "get_torrents"
+
+    fields = opts.fetch(:fields) { self.fields }
 
     response =
       post(

--- a/test/client_test.rb
+++ b/test/client_test.rb
@@ -108,6 +108,19 @@ class ClientTest < Minitest::Test
     assert_equal( "torrents", @client.all )
   end
 
+  def test_all_accepts_list_of_fields
+    opts_expected = {
+      :method => "torrent-get",
+      :arguments => { :fields => ["overridden_field"] }
+    }
+    result = { "arguments" => { "torrents" => "torrents" } }
+
+    @client.stubs(:fields).returns(["default_field"])
+    @client.expects(:post).with( opts_expected ).returns( result )
+
+    assert_equal( "torrents", @client.all(fields: ['overridden_field']) )
+  end
+
   def test_find
     opts_expected = {
       :method => "torrent-get",

--- a/test/client_test.rb
+++ b/test/client_test.rb
@@ -134,6 +134,32 @@ class ClientTest < Minitest::Test
     assert_equal( "torrent1", @client.find(1) )
   end
 
+  def test_find_accepts_fields
+    opts_expected = {
+      :method => "torrent-get",
+      :arguments => { :fields => ['id'], :ids => [1] }
+    }
+    result = { "arguments" => { "torrents" => ["torrent1"] } }
+
+    @client.stubs(:fields).returns("fields")
+    @client.expects(:post).with( opts_expected ).returns( result )
+
+    assert_equal( "torrent1", @client.find(1, fields: ['id']) )
+  end
+
+  def test_get_torrents
+    opts_expected = {
+      :method => "torrent-get",
+      :arguments => :test_arguments
+    }
+    result = { "arguments" => { "torrents" => ["torrent1"] } }
+
+    @client.stubs(:fields).returns("fields")
+    @client.expects(:post).with( opts_expected ).returns( result )
+
+    assert_equal( ["torrent1"], @client.get_torrents(:test_arguments) )
+  end
+
   def test_create
     opts_expected = {
       :method => "torrent-add",


### PR DESCRIPTION
Added ability to override .all and .find fields
Now you can specify fields you'd like to fetch with all method.
For example:

``` ruby
client.all(fields: ['id', 'name', 'addedDate'])
client.find(1, fields: ['id', 'name', 'addedDate'])
```

will fetch only id, name and added date.
It works the same as before if called without arguments
