### PR TITLE
Update HTTParty dependency version

### DIFF
--- a/transmission_api.gemspec
+++ b/transmission_api.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = TransmissionApi::VERSION
 
-  gem.add_dependency "httparty", "0.9.0"
+  gem.add_dependency "httparty", "~> 0.14.0"
 
   gem.add_development_dependency "mocha", "~> 1.1.0"
   gem.add_development_dependency "minitest", "~> 5.4.0"


### PR DESCRIPTION
Simple update to the version. This will allow me to use this gem along other gems that require httparty at newer versions